### PR TITLE
fix: update to rust nightly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,3 @@
-#![feature(fs)]
-#![feature(io)]
-#![feature(path)]
-
 extern crate bindgen;
 
 use bindgen::{Bindings, BindgenOptions};

--- a/examples/buffered.rs
+++ b/examples/buffered.rs
@@ -1,6 +1,4 @@
-#![feature(io)]
-
-use std::io::{ReadExt, self};
+use std::io::{Read, self};
 
 fn main() {
     let stdin = io::stdin();

--- a/examples/unbuffered.rs
+++ b/examples/unbuffered.rs
@@ -1,10 +1,9 @@
-#![feature(io)]
 #![feature(libc)]
 
 extern crate libc;
 extern crate termios;
 
-use std::io::{ReadExt, self};
+use std::io::{Read, self};
 
 use termios::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ impl Termios {
     ///
     /// ``` no_run
     /// // examples/buffered.rs
-    /// use std::io::{ReadExt, self};
+    /// use std::io::{Read, self};
     ///
     /// fn main() {
     ///     let stdin = io::stdin();
@@ -156,7 +156,7 @@ impl Termios {
     /// extern crate libc;
     /// extern crate termios;
     ///
-    /// use std::io::{ReadExt, self};
+    /// use std::io::{Read, self};
     ///
     /// use termios::prelude::*;
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(missing_docs, warnings)]
-#![feature(io)]
 #![feature(libc)]
 
 //! Termios bindings + safe wrapper


### PR DESCRIPTION
Recent nightly changes prevents termios.rs (and serial.rs) to be build:

```
src/lib.rs:2:12: 2:14 error: unused or unknown feature, #[deny(unused_features)] on by default
src/lib.rs:2 #![feature(io)]
```
